### PR TITLE
Disable debug in test and update poetry installation

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -46,6 +46,7 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
           installer-parallel: true
+          installation-arguments: --with=testing
       - name: Install dependencies
         run: poetry install --no-interaction --with testing
       - name: Run PyTest with coverage

--- a/tests/test_todoon.py
+++ b/tests/test_todoon.py
@@ -279,7 +279,7 @@ class TestTodoon(unittest.TestCase):
             ("GITHUB_REF_NAME", "branch"),
             ("GITHUB_TRIGGERING_ACTOR", "pytest"),
         ]
-        self._environment_up("singular", env_variables=env)
+        self._environment_up("singular", env_variables=env, disable_debug=True)
 
         td.todoon(print_mode=False, silent=True)
 


### PR DESCRIPTION
Added a `disable_debug` flag while setting up the environment in test_todoon.py to prevent unnecessary debug logs. Updated the GitHub Actions workflow to include installation arguments specific for testing.

Please go to the `Preview` tab and select the appropriate sub-template:

* [Default](?expand=1&template=default.md)
* [Documentation](?expand=1&template=documentation.md)
* [Patch](?expand=1&template=patch.md)
* [Localization](?expand=1&template=localization.md)
