### PR TITLE
PATCH: Durable URL for auth token

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -61,7 +61,7 @@ runs:
       shell: bash
       run: |
         # URL of the API endpoint
-        URL="http://ec2-13-59-26-12.us-east-2.compute.amazonaws.com/token"
+        URL="http://todoon-auth.trentonyo.com/token"
         # JSON payload
         PAYLOAD='{"app_id": "853479"}'
         # Make the POST request and capture the response


### PR DESCRIPTION
🔨 PATCH: Durable URL for auth token
===========

Old State
-----------

URL for auth token could change

New State
-----------

URL for auth token now directed from an owned domain

Definition of Done (pertinent to patch)
------------------

* [x] Contains no breaking changes
* [x] Changes are implemented in all components
* [x] Each component associated with issue is updated (no stubs)
* [x] All tests pass, no regressions
* [x] All documentation is updated, including release notes
