### PR TITLE
PATCH: Version Bumps

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2,33 +2,33 @@
 
 [[package]]
 name = "black"
-version = "24.8.0"
+version = "24.10.0"
 description = "The uncompromising code formatter."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 files = [
-    {file = "black-24.8.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:09cdeb74d494ec023ded657f7092ba518e8cf78fa8386155e4a03fdcc44679e6"},
-    {file = "black-24.8.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:81c6742da39f33b08e791da38410f32e27d632260e599df7245cccee2064afeb"},
-    {file = "black-24.8.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:707a1ca89221bc8a1a64fb5e15ef39cd755633daa672a9db7498d1c19de66a42"},
-    {file = "black-24.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:d6417535d99c37cee4091a2f24eb2b6d5ec42b144d50f1f2e436d9fe1916fe1a"},
-    {file = "black-24.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:fb6e2c0b86bbd43dee042e48059c9ad7830abd5c94b0bc518c0eeec57c3eddc1"},
-    {file = "black-24.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:837fd281f1908d0076844bc2b801ad2d369c78c45cf800cad7b61686051041af"},
-    {file = "black-24.8.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62e8730977f0b77998029da7971fa896ceefa2c4c4933fcd593fa599ecbf97a4"},
-    {file = "black-24.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:72901b4913cbac8972ad911dc4098d5753704d1f3c56e44ae8dce99eecb0e3af"},
-    {file = "black-24.8.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:7c046c1d1eeb7aea9335da62472481d3bbf3fd986e093cffd35f4385c94ae368"},
-    {file = "black-24.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:649f6d84ccbae73ab767e206772cc2d7a393a001070a4c814a546afd0d423aed"},
-    {file = "black-24.8.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2b59b250fdba5f9a9cd9d0ece6e6d993d91ce877d121d161e4698af3eb9c1018"},
-    {file = "black-24.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:6e55d30d44bed36593c3163b9bc63bf58b3b30e4611e4d88a0c3c239930ed5b2"},
-    {file = "black-24.8.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:505289f17ceda596658ae81b61ebbe2d9b25aa78067035184ed0a9d855d18afd"},
-    {file = "black-24.8.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:b19c9ad992c7883ad84c9b22aaa73562a16b819c1d8db7a1a1a49fb7ec13c7d2"},
-    {file = "black-24.8.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1f13f7f386f86f8121d76599114bb8c17b69d962137fc70efe56137727c7047e"},
-    {file = "black-24.8.0-cp38-cp38-win_amd64.whl", hash = "sha256:f490dbd59680d809ca31efdae20e634f3fae27fba3ce0ba3208333b713bc3920"},
-    {file = "black-24.8.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:eab4dd44ce80dea27dc69db40dab62d4ca96112f87996bca68cd75639aeb2e4c"},
-    {file = "black-24.8.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3c4285573d4897a7610054af5a890bde7c65cb466040c5f0c8b732812d7f0e5e"},
-    {file = "black-24.8.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9e84e33b37be070ba135176c123ae52a51f82306def9f7d063ee302ecab2cf47"},
-    {file = "black-24.8.0-cp39-cp39-win_amd64.whl", hash = "sha256:73bbf84ed136e45d451a260c6b73ed674652f90a2b3211d6a35e78054563a9bb"},
-    {file = "black-24.8.0-py3-none-any.whl", hash = "sha256:972085c618ee94f402da1af548a4f218c754ea7e5dc70acb168bfaca4c2542ed"},
-    {file = "black-24.8.0.tar.gz", hash = "sha256:2500945420b6784c38b9ee885af039f5e7471ef284ab03fa35ecdde4688cd83f"},
+    {file = "black-24.10.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e6668650ea4b685440857138e5fe40cde4d652633b1bdffc62933d0db4ed9812"},
+    {file = "black-24.10.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1c536fcf674217e87b8cc3657b81809d3c085d7bf3ef262ead700da345bfa6ea"},
+    {file = "black-24.10.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:649fff99a20bd06c6f727d2a27f401331dc0cc861fb69cde910fe95b01b5928f"},
+    {file = "black-24.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:fe4d6476887de70546212c99ac9bd803d90b42fc4767f058a0baa895013fbb3e"},
+    {file = "black-24.10.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5a2221696a8224e335c28816a9d331a6c2ae15a2ee34ec857dcf3e45dbfa99ad"},
+    {file = "black-24.10.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f9da3333530dbcecc1be13e69c250ed8dfa67f43c4005fb537bb426e19200d50"},
+    {file = "black-24.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4007b1393d902b48b36958a216c20c4482f601569d19ed1df294a496eb366392"},
+    {file = "black-24.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:394d4ddc64782e51153eadcaaca95144ac4c35e27ef9b0a42e121ae7e57a9175"},
+    {file = "black-24.10.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b5e39e0fae001df40f95bd8cc36b9165c5e2ea88900167bddf258bacef9bbdc3"},
+    {file = "black-24.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d37d422772111794b26757c5b55a3eade028aa3fde43121ab7b673d050949d65"},
+    {file = "black-24.10.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14b3502784f09ce2443830e3133dacf2c0110d45191ed470ecb04d0f5f6fcb0f"},
+    {file = "black-24.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:30d2c30dc5139211dda799758559d1b049f7f14c580c409d6ad925b74a4208a8"},
+    {file = "black-24.10.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1cbacacb19e922a1d75ef2b6ccaefcd6e93a2c05ede32f06a21386a04cedb981"},
+    {file = "black-24.10.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1f93102e0c5bb3907451063e08b9876dbeac810e7da5a8bfb7aeb5a9ef89066b"},
+    {file = "black-24.10.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ddacb691cdcdf77b96f549cf9591701d8db36b2f19519373d60d31746068dbf2"},
+    {file = "black-24.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:680359d932801c76d2e9c9068d05c6b107f2584b2a5b88831c83962eb9984c1b"},
+    {file = "black-24.10.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:17374989640fbca88b6a448129cd1745c5eb8d9547b464f281b251dd00155ccd"},
+    {file = "black-24.10.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:63f626344343083322233f175aaf372d326de8436f5928c042639a4afbbf1d3f"},
+    {file = "black-24.10.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfa1d0cb6200857f1923b602f978386a3a2758a65b52e0950299ea014be6800"},
+    {file = "black-24.10.0-cp39-cp39-win_amd64.whl", hash = "sha256:2cd9c95431d94adc56600710f8813ee27eea544dd118d45896bb734e9d7a0dc7"},
+    {file = "black-24.10.0-py3-none-any.whl", hash = "sha256:3bb2b7a1f7b685f85b11fed1ef10f8a9148bceb49853e47a294a3dd963c1dd7d"},
+    {file = "black-24.10.0.tar.gz", hash = "sha256:846ea64c97afe3bc677b761787993be4991810ecc7a4a937816dd6bddedc4875"},
 ]
 
 [package.dependencies]
@@ -40,7 +40,7 @@ platformdirs = ">=2"
 
 [package.extras]
 colorama = ["colorama (>=0.4.3)"]
-d = ["aiohttp (>=3.7.4)", "aiohttp (>=3.7.4,!=3.9.0)"]
+d = ["aiohttp (>=3.10)"]
 jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
 uvloop = ["uvloop (>=0.15.2)"]
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -506,20 +506,21 @@ files = [
 
 [[package]]
 name = "tqdm"
-version = "4.66.5"
+version = "4.67.1"
 description = "Fast, Extensible Progress Meter"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "tqdm-4.66.5-py3-none-any.whl", hash = "sha256:90279a3770753eafc9194a0364852159802111925aa30eb3f9d85b0e805ac7cd"},
-    {file = "tqdm-4.66.5.tar.gz", hash = "sha256:e1020aef2e5096702d8a025ac7d16b1577279c9d63f8375b63083e9a5f0fcbad"},
+    {file = "tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2"},
+    {file = "tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2"},
 ]
 
 [package.dependencies]
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
 
 [package.extras]
-dev = ["pytest (>=6)", "pytest-cov", "pytest-timeout", "pytest-xdist"]
+dev = ["nbval", "pytest (>=6)", "pytest-asyncio (>=0.24)", "pytest-cov", "pytest-timeout"]
+discord = ["requests"]
 notebook = ["ipywidgets (>=6)"]
 slack = ["slack-sdk"]
 telegram = ["requests"]

--- a/poetry.lock
+++ b/poetry.lock
@@ -526,13 +526,13 @@ telegram = ["requests"]
 
 [[package]]
 name = "typer"
-version = "0.12.5"
+version = "0.13.1"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "typer-0.12.5-py3-none-any.whl", hash = "sha256:62fe4e471711b147e3365034133904df3e235698399bc4de2b36c8579298d52b"},
-    {file = "typer-0.12.5.tar.gz", hash = "sha256:f592f089bedcc8ec1b974125d64851029c3b1af145f04aca64d69410f0c9b722"},
+    {file = "typer-0.13.1-py3-none-any.whl", hash = "sha256:5b59580fd925e89463a29d363e0a43245ec02765bde9fb77d39e5d0f29dd7157"},
+    {file = "typer-0.13.1.tar.gz", hash = "sha256:9d444cb96cc268ce6f8b94e13b4335084cef4c079998a9f4851a90229a3bd25c"},
 ]
 
 [package.dependencies]
@@ -572,4 +572,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "c684130955a877659e8552db29eb9e6b101b4fb2ba75a4e89d69806eb2cf2309"
+content-hash = "bf09053d4eb349bd9c2750ee7391d5485f669616e7e67590e18f69a18e3f3e8b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ documentation = "https://github.com/Start-Out/todo-or-not/wiki"
 
 [tool.poetry.dependencies]
 python = "^3.11"
-typer = "^0.12.3"
+typer = ">=0.12.3,<0.14.0"
 typing-extensions = "^4.10.0"
 tqdm = "^4.66.4"
 ply = "^3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "todo-or-not"
-version = "0.13.25"
+version = "0.13.26"
 description = "todoon integrates the TODOs in your codebase with your GitHub repository"
 authors = ["TrentonYo <trentonyo@gmail.com>"]
 license = "GPL-3.0-only"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "todo-or-not"
-version = "0.14.7"
+version = "0.14.8"
 description = "todoon integrates the TODOs in your codebase with your GitHub repository"
 authors = ["TrentonYo <trentonyo@gmail.com>"]
 license = "GPL-3.0-only"

--- a/tests/test_github_issues.py
+++ b/tests/test_github_issues.py
@@ -93,7 +93,7 @@ def test_unformatted_hits_not_formatted(
 
 class TestIssueHelperFunctions(unittest.TestCase):
     def test_hash(self):
-        output = todo_or_not.utility.sha1_hash("test")
+        output = todo_or_not.utility.str_hash("test")
         self.assertEqual(
             output, "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3"
         )  # add assertion here

--- a/tests/test_todoignore_util.py
+++ b/tests/test_todoignore_util.py
@@ -217,6 +217,7 @@ class TestTodoignoreUtil(unittest.TestCase):
         os.remove(".todo-ignore")
 
         # Run util
+        # TODO there is a PermissionError here
         td.todo_ignore_util(["res"], source_is_text=False)
 
         # Tear down

--- a/tests/test_todoon.py
+++ b/tests/test_todoon.py
@@ -182,7 +182,7 @@ class TestTodoon(unittest.TestCase):
         env = [
             ("GITHUB_REPOSITORY", "Start-Out/todo-or-not"),
             ("GITHUB_REF_NAME", "branch"),
-            ("GITHUB_TRIGGERING_ACTOR", "pytest"),
+            ("GITHUB_TRIGGERING_ACTOR", "trentonyo"),
             ("MAXIMUM_ISSUES_GENERATED", "1"),
         ]
         self._environment_up("no_todos", env_variables=env)
@@ -196,7 +196,7 @@ class TestTodoon(unittest.TestCase):
         env = [
             ("GITHUB_REPOSITORY", "github/gitignore"),
             ("GITHUB_REF_NAME", "branch"),
-            ("GITHUB_TRIGGERING_ACTOR", "pytest"),
+            ("GITHUB_TRIGGERING_ACTOR", "trentonyo"),
         ]
         self._environment_up("specific_files", env_variables=env, disable_debug=True)
 
@@ -211,7 +211,7 @@ class TestTodoon(unittest.TestCase):
         env = [
             ("GITHUB_REPOSITORY", "Start-Out/todo-or-not"),
             ("GITHUB_REF_NAME", "branch"),
-            ("GITHUB_TRIGGERING_ACTOR", "pytest"),
+            ("GITHUB_TRIGGERING_ACTOR", "trentonyo"),
             ("MAXIMUM_ISSUES_GENERATED", "1"),
         ]
         self._environment_up("specific_files", env_variables=env)
@@ -225,7 +225,7 @@ class TestTodoon(unittest.TestCase):
         env = [
             ("GITHUB_REPOSITORY", "Start-Out/todo-or-not"),
             ("GITHUB_REF_NAME", "branch"),
-            ("GITHUB_TRIGGERING_ACTOR", "pytest"),
+            ("GITHUB_TRIGGERING_ACTOR", "trentonyo"),
         ]
         self._environment_up("closed_issue", env_variables=env, disable_debug=True)
 
@@ -238,7 +238,7 @@ class TestTodoon(unittest.TestCase):
         env = [
             ("GITHUB_REPOSITORY", "Start-Out/todo-or-not"),
             ("GITHUB_REF_NAME", "branch"),
-            ("GITHUB_TRIGGERING_ACTOR", "pytest"),
+            ("GITHUB_TRIGGERING_ACTOR", "trentonyo"),
         ]
         self._environment_up("no_todos", env_variables=env, disable_debug=True)
 
@@ -250,7 +250,7 @@ class TestTodoon(unittest.TestCase):
         env = [
             ("GITHUB_REPOSITORY", "Start-Out/todo-or-not"),
             ("GITHUB_REF_NAME", "branch"),
-            ("GITHUB_TRIGGERING_ACTOR", "pytest"),
+            ("GITHUB_TRIGGERING_ACTOR", "trentonyo"),
         ]
         self._environment_up("closed_issue", env_variables=env, disable_debug=True)
 
@@ -277,7 +277,7 @@ class TestTodoon(unittest.TestCase):
         env = [
             ("GITHUB_REPOSITORY", "Start-Out/todo-or-not"),
             ("GITHUB_REF_NAME", "branch"),
-            ("GITHUB_TRIGGERING_ACTOR", "pytest"),
+            ("GITHUB_TRIGGERING_ACTOR", "trentonyo"),
         ]
         self._environment_up("singular", env_variables=env, disable_debug=True)
 
@@ -286,7 +286,7 @@ class TestTodoon(unittest.TestCase):
         # number of issues
         assert os.environ["TODOON_ISSUES_GENERATED"] == "0"
         # number of duplicate issues
-        assert os.environ["TODOON_DUPLICATE_ISSUES_AVOIDED"] == "0"
+        assert os.environ["TODOON_DUPLICATE_ISSUES_AVOIDED"] == "1"
         # number of closed issues
         assert os.environ["TODOON_DUPLICATE_CLOSED_ISSUES"] == "1"
 
@@ -296,18 +296,19 @@ class TestTodoon(unittest.TestCase):
         env = [
             ("GITHUB_REPOSITORY", "Start-Out/todo-or-not"),
             ("GITHUB_REF_NAME", "branch"),
-            ("GITHUB_TRIGGERING_ACTOR", "pytest"),
+            ("GITHUB_TRIGGERING_ACTOR", "trentonyo"),
         ]
-        self._environment_up("plural", env_variables=env, disable_debug=True)
+        # Debug remains enabled so that issues are not accidentally created
+        self._environment_up("plural", env_variables=env, disable_debug=False)
 
         td.todoon(print_mode=False, silent=True)
 
-        # number of issues
-        assert os.environ["TODOON_ISSUES_GENERATED"] == "0"
+        # number of issues should be 4 (though not actual created)
+        assert os.environ["TODOON_ISSUES_GENERATED"] == "4"
         # number of duplicate issues
-        assert os.environ["TODOON_DUPLICATE_ISSUES_AVOIDED"] == "3"
+        assert os.environ["TODOON_DUPLICATE_ISSUES_AVOIDED"] == "0"
         # number of closed issues
-        assert os.environ["TODOON_DUPLICATE_CLOSED_ISSUES"] == "1"
+        assert os.environ["TODOON_DUPLICATE_CLOSED_ISSUES"] == "0"
 
         self._environment_down()
 
@@ -342,9 +343,10 @@ class TestTodoon(unittest.TestCase):
 
         td.todoon(push_github_env_vars=True)
 
-        assert os.path.isfile("github_environment.txt")
+        output_file_name = "github_environment.txt" if os.name == 'posix' else "$GITHUB_ENV"
 
-        os.remove("github_environment.txt")
+        assert os.path.isfile(output_file_name)
+        os.remove(output_file_name)
 
         self._environment_down()
 

--- a/todo_or_not/localize.py
+++ b/todo_or_not/localize.py
@@ -33,6 +33,7 @@ LOCALIZE = {
         "error_exceeded_maximum_issues": "ERROR: Exceeded maximum number of issues for this run, exiting now",
         "warning_force_overrides_ignore": "WARNING: --force will ignore the contents of the .todo-ignore generated when you specified (.todo-ignore will still be changed, just not used)",
         "warning_file_does_not_exist": "WARNING: File doesn't exist",
+        "warning_file_permission_error": "WARNING: File permission error",
         "warning_is_a_directory": "WARNING: Expected a file, got a directory",
         "warning_run_with_empty_todo_ignore": "WARNING: .todo-ignore was empty (if the file isn't empty, check its encoding), running anyway. To cancel use ",
         "warning_run_without_todo_ignore": "WARNING: Running without a .todo-ignore, to cancel use ",

--- a/todo_or_not/todo_app.py
+++ b/todo_or_not/todo_app.py
@@ -55,28 +55,28 @@ class TodoRun:
         os.environ["TODOON_DUPLICATE_CLOSED_ISSUES"] = str(self.number_of_closed_issues)
 
         if self.push_github_env_vars:
-            os.system(f'echo TODOON_STATUS={"finished"} >> $GITHUB_ENV')
-            os.system(f'echo TODOON_PROGRESS={"100.0"} >> $GITHUB_ENV')
+            os.system(f'echo TODOON_STATUS={"finished"} >> \"$GITHUB_ENV\"')
+            os.system(f'echo TODOON_PROGRESS={"100.0"} >> \"$GITHUB_ENV\"')
             os.system(
-                f"echo TODOON_FILES_SCANNED={str(self.number_of_files_scanned)} >> $GITHUB_ENV"
+                f"echo TODOON_FILES_SCANNED={str(self.number_of_files_scanned)} >> \"$GITHUB_ENV\""
             )
             os.system(
-                f"echo TODOON_TODOS_FOUND={str(self.number_of_todo)} >> $GITHUB_ENV"
+                f"echo TODOON_TODOS_FOUND={str(self.number_of_todo)} >> \"$GITHUB_ENV\""
             )
             os.system(
-                f"echo TODOON_FIXMES_FOUND={str(self.number_of_fixme)} >> $GITHUB_ENV"
+                f"echo TODOON_FIXMES_FOUND={str(self.number_of_fixme)} >> \"$GITHUB_ENV\""
             )
             os.system(
-                f"echo TODOON_ENCODING_ERRORS={str(self.number_of_encoding_failures)} >> $GITHUB_ENV"
+                f"echo TODOON_ENCODING_ERRORS={str(self.number_of_encoding_failures)} >> \"$GITHUB_ENV\""
             )
             os.system(
-                f"echo TODOON_ISSUES_GENERATED={str(self.number_of_issues)} >> $GITHUB_ENV"
+                f"echo TODOON_ISSUES_GENERATED={str(self.number_of_issues)} >> \"$GITHUB_ENV\""
             )
             os.system(
-                f"echo TODOON_DUPLICATE_ISSUES_AVOIDED={str(self.number_of_duplicate_issues_avoided)} >> $GITHUB_ENV"
+                f"echo TODOON_DUPLICATE_ISSUES_AVOIDED={str(self.number_of_duplicate_issues_avoided)} >> \"$GITHUB_ENV\""
             )
             os.system(
-                f"echo TODOON_DUPLICATE_CLOSED_ISSUES={str(self.number_of_closed_issues)} >> $GITHUB_ENV"
+                f"echo TODOON_DUPLICATE_CLOSED_ISSUES={str(self.number_of_closed_issues)} >> \"$GITHUB_ENV\""
             )
 
     def generate_summary_message(self):

--- a/todo_or_not/todo_check.py
+++ b/todo_or_not/todo_check.py
@@ -461,7 +461,7 @@ def todoon(
 
         if todoon_created_issues is not False:
             for issue in todoon_created_issues:
-                existing_issues_hashed[util.sha1_hash(issue["title"])] = issue["state"]
+                existing_issues_hashed[util.str_hash(issue["title"])] = issue["state"]
         else:
             util.print_wrap(log_level=log_level,
                             msg=f"{loc('error_gh_issues_read_failed')}", file=sys.stderr
@@ -513,7 +513,7 @@ def todoon(
                 # Special handling for the ISSUE mode
 
                 if not print_mode:
-                    _this_hit_hashed = util.sha1_hash(hit.get_title())
+                    _this_hit_hashed = util.str_hash(hit.get_title())
 
                     # Check if the app already created this hit's title in open AND closed issues
                     if _this_hit_hashed not in existing_issues_hashed:
@@ -622,6 +622,9 @@ def todo_ignore_util(
                                 output.append(line)
                 except FileNotFoundError:
                     print(loc("warning_file_does_not_exist"), _path, file=sys.stderr)
+                except PermissionError:
+                    #TODO NEW Localization 'warning_file_permission_error' | "WARNING: File permission error" #localization
+                    print(loc("warning_file_permission_error"), _path, file=sys.stderr)
                 except IsADirectoryError:
                     print(loc("warning_is_a_directory"), _path, file=sys.stderr)
 

--- a/todo_or_not/utility.py
+++ b/todo_or_not/utility.py
@@ -91,8 +91,8 @@ def get_os(log_level=LOG_LEVEL_NORMAL):
     return _os
 
 
-def sha1_hash(hit_str: str):
-    m = hashlib.sha1()
+def str_hash(hit_str: str):
+    m = hashlib.sha1(usedforsecurity=False)
     m.update(bytes(hit_str, "utf-8"))
     return m.hexdigest()
 


### PR DESCRIPTION
🔨 PATCH: Version Bumps
===========

Updates
-----------

- `black` 24.8.0 -> 24.10.0
- `tqdm` 4.66.5 -> 4.67.1 
- `typer` 0.12.5 -> 0.13.1

Fixes
-----------

- Added file permissions check in todoignore util
- Fixed test misbehaving on non-unix
- Tweaked naming for a small hashmap utility

Definition of Done (pertinent to patch)
------------------

* [x] Contains no breaking changes
* [x] Changes are implemented in all components
* [x] Each component associated with issue is updated (no stubs)
* [x] All tests pass, no regressions
* [x] All documentation is updated, including release notes
