### PR TITLE
FIX: Don't run issue creation for forks

### DIFF
--- a/.github/workflows/todoon-issues-prod.yml
+++ b/.github/workflows/todoon-issues-prod.yml
@@ -14,7 +14,6 @@ on:
       - dev/staging
 jobs:
   run_todoon:
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     environment: testing
     steps:
@@ -28,19 +27,27 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install todo-or-not
       - name: Generate GH Token for todoon app
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         id: generate-token
         uses: actions/create-github-app-token@v1
         with:
           app-id: 853479
           private-key: ${{ secrets.TODOON_CLIENT_PEM }}
-      - name: Run TODO-or-not
+      - name: Run TODO-or-not in issue mode
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         env:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
           MAXIMUM_ISSUES_GENERATED: 10
         run: |
           echo "Generate GitHub issues for each problem found, but don't fail the workflow unless one is found that has already been closed."
           todoon -si --github-env
+      - name: Run TODO-or-not in check mode for fork PRs
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+        run: |
+          echo "Running TODO-or-not in check mode because this is a fork PR and secrets are unavailable."
+          todoon --silent
       - name: Check duplicate closed issues
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         run: |
           if [ "${{ env.TODOON_DUPLICATE_CLOSED_ISSUES }}" != "1" ]; then
             echo "Detected ${{ env.TODOON_DUPLICATE_CLOSED_ISSUES }} duplicate closed issues where we expected exactly one (an example), failing this workflow!"

--- a/.github/workflows/todoon-issues-prod.yml
+++ b/.github/workflows/todoon-issues-prod.yml
@@ -14,6 +14,7 @@ on:
       - dev/staging
 jobs:
   run_todoon:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     environment: testing
     steps:


### PR DESCRIPTION
🔨 PATCH: Contributors don't trigger issue workflow
===========

Old State
-----------

The 'todoon-issues-prod.yml' workflow would try to run on contributor forks which don't have access to the PEM for generating issues.

New State
-----------

Contributions no longer trigger the body of the workflow. This will also prevent abuse, win-win.

Definition of Done (pertinent to patch)
------------------

* [x] Contains no breaking changes
* [x] Changes are implemented in all components
* [x] Each component associated with issue is updated (no stubs)
* [x] All tests pass, no regressions
* [x] All documentation is updated, including release notes
